### PR TITLE
[Homework] Liquid basics

### DIFF
--- a/assets/banner-product.js
+++ b/assets/banner-product.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const colorButtons = document.querySelectorAll(".color-button");
+  const quantityDisplay = document.querySelector(
+    ".product--inventory_quantity>span"
+  );
+  const addToCartButton = document.querySelector(".add-to-cart");
+
+  colorButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const variantId = button.getAttribute("data-variant-id");
+      const color = button.getAttribute("data-color");
+      const available = button.getAttribute("data-available");
+
+      // Handle color selection
+      colorButtons.forEach((btn) => btn.classList.remove("active"));
+      button.classList.add("active");
+
+      // Update quantity display
+      if (available > 0) {
+        quantityDisplay.textContent = `In stock: ${available}`;
+      } else if (available == "available") {
+        quantityDisplay.textContent = "In stock";
+      } else {
+        quantityDisplay.textContent = "Out of stock";
+      }
+    });
+  });
+
+  addToCartButton.addEventListener("click", () => {
+    // Handle add to cart
+  });
+});

--- a/assets/banner-product.js
+++ b/assets/banner-product.js
@@ -1,11 +1,43 @@
-document.addEventListener("DOMContentLoaded", () => {
-  const currentSection = document.querySelector(".section__product-banner");
-  const colorButtons = document.querySelectorAll(".color-button");
-  const quantityDisplay = document.querySelector(
-    ".product--inventory_quantity>span"
-  );
-  const addToCartButton = document.querySelector(".add-to-cart");
+const currentSection = document.querySelector(".section__product-banner");
 
+// Handle product image gallery
+function initProductGallery() {
+  const mainImage = currentSection.querySelector(".main-image img");
+  const thumbs = currentSection.querySelectorAll(".gallery-thumb");
+
+  if (!mainImage || !thumbs.length) return;
+
+  thumbs.forEach((thumb) => {
+    thumb.addEventListener("click", (e) => {
+      const mainImageUrl = thumb.dataset.large;
+      const mainImageAlt = thumb.alt;
+      const thumbWrapper = thumb.closest(".product-gallery__item");
+
+      if (thumb.dataset.srcset) {
+        mainImage.srcset = thumb.dataset.srcset;
+        mainImage.sizes = thumb.dataset.sizes;
+      }
+
+      mainImage.src = mainImageUrl;
+      mainImage.alt = mainImageAlt;
+
+      // Update active thumbnail styling
+      currentSection
+        .querySelectorAll(".product-gallery__item")
+        .forEach((item) => item.classList.remove("active"));
+      thumbWrapper.classList.add("active");
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initProductGallery);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const colorButtons = currentSection.querySelectorAll(".color-button");
+
+  const addToCartButton = currentSection.querySelector(".add-to-cart");
+
+  // Handle color selection and variant update
   colorButtons.forEach((button) => {
     button.addEventListener("click", () => {
       const variantId = button.dataset.variantId;
@@ -31,16 +63,8 @@ document.addEventListener("DOMContentLoaded", () => {
           ).innerHTML;
           currentSection.querySelector(".product-images").innerHTML =
             tempDiv.querySelector(".product-images").innerHTML;
+          initProductGallery();
         });
-
-      // Update quantity display
-      // if (available > 0) {
-      //   quantityDisplay.textContent = `In stock: ${available}`;
-      // } else if (available == "available") {
-      //   quantityDisplay.textContent = "In stock";
-      // } else {
-      //   quantityDisplay.textContent = "Out of stock";
-      // }
     });
   });
 

--- a/assets/banner-product.js
+++ b/assets/banner-product.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const currentSection = document.querySelector(".section__product-banner");
   const colorButtons = document.querySelectorAll(".color-button");
   const quantityDisplay = document.querySelector(
     ".product--inventory_quantity>span"
@@ -7,22 +8,39 @@ document.addEventListener("DOMContentLoaded", () => {
 
   colorButtons.forEach((button) => {
     button.addEventListener("click", () => {
-      const variantId = button.getAttribute("data-variant-id");
-      const color = button.getAttribute("data-color");
-      const available = button.getAttribute("data-available");
+      const variantId = button.dataset.variantId;
+      const productHandle = button.dataset.productHandle;
 
       // Handle color selection
       colorButtons.forEach((btn) => btn.classList.remove("active"));
       button.classList.add("active");
 
+      // Update variant information with Section Rendering API
+      const url = `/products/${productHandle}?variant=${variantId}&sections=banner-product`;
+      fetch(url)
+        .then((response) => response.json())
+        .then((data) => {
+          const tempDiv = document.createElement("div");
+          tempDiv.innerHTML = data["banner-product"];
+          currentSection.querySelector(".price-container").innerHTML =
+            tempDiv.querySelector(".price-container").innerHTML;
+          currentSection.querySelector(
+            ".product--inventory_quantity"
+          ).innerHTML = tempDiv.querySelector(
+            ".product--inventory_quantity"
+          ).innerHTML;
+          currentSection.querySelector(".product-images").innerHTML =
+            tempDiv.querySelector(".product-images").innerHTML;
+        });
+
       // Update quantity display
-      if (available > 0) {
-        quantityDisplay.textContent = `In stock: ${available}`;
-      } else if (available == "available") {
-        quantityDisplay.textContent = "In stock";
-      } else {
-        quantityDisplay.textContent = "Out of stock";
-      }
+      // if (available > 0) {
+      //   quantityDisplay.textContent = `In stock: ${available}`;
+      // } else if (available == "available") {
+      //   quantityDisplay.textContent = "In stock";
+      // } else {
+      //   quantityDisplay.textContent = "Out of stock";
+      // }
     });
   });
 

--- a/assets/section-banner-product.css
+++ b/assets/section-banner-product.css
@@ -54,13 +54,13 @@
   display: none;
 }
 
-.product-gallery .image-container {
+.product-gallery .product-gallery__item {
   position: relative;
   border-radius: 0.5rem;
   overflow: hidden;
 }
 
-.product-gallery .image-container.active::before {
+.product-gallery .product-gallery__item.active::before {
   content: "";
   position: absolute;
   top: 0;

--- a/assets/section-banner-product.css
+++ b/assets/section-banner-product.css
@@ -1,0 +1,191 @@
+.section__product-banner {
+  padding-top: 36px;
+  padding-bottom: 12px;
+}
+.product-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.product-images {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+.product-images .main-image {
+  position: relative;
+}
+
+.product-images .main-image .badge {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+  background-color: var(--color-white);
+  text-transform: capitalize;
+}
+
+.product-images .main-image img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  aspect-ratio: 1 / 1;
+  border-radius: 0.5rem;
+}
+
+.product-gallery {
+  display: flex;
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.product-gallery.hidden {
+  display: none;
+}
+
+.product-gallery .image-container {
+  position: relative;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.product-gallery .image-container.active::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(17, 17, 17, 0.2);
+}
+
+.product-gallery img {
+  max-width: 88px;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  aspect-ratio: 1 / 1;
+}
+
+.product-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.product-info .price-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.product-info .price {
+  color: var(--color-foreground);
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.product-info .price--compare {
+  text-decoration: line-through;
+  font-weight: 300;
+}
+
+.product-info .price--muted {
+  opacity: 0.6;
+}
+
+.product-info .badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.product-info .badge.badge--soldout {
+  background-color: #808080;
+}
+
+.product-info .badge.badge--sale {
+  background-color: #dc143c;
+}
+
+.product-info .color-options {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.product-info .color-button {
+  padding: 0;
+  width: 88px;
+  height: 88px;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  overflow: hidden;
+}
+
+.product-info .color-button.active {
+  border-color: var(--text-primary);
+}
+
+.product-info .color-button img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.product-info .size-options .grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.product-info .size-options .size-button {
+  padding: 1rem;
+  height: 52px;
+  font-size: 0.85rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  background-color: var(--color-white);
+}
+
+.product-info .size-options .size-button.active,
+.product-info .size-options .size-button:hover {
+  border-color: var(--text-primary);
+}
+
+.product-info .add-to-cart {
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .product-card {
+    flex-direction: row;
+  }
+  .product-card .product-images,
+  .product-card .product-info {
+    flex: 1;
+  }
+}
+
+@media (min-width: 1280px) {
+  .product-images {
+    flex-direction: row-reverse;
+    gap: 1.5rem;
+  }
+  .product-gallery {
+    flex-direction: column;
+    gap: 1.5rem;
+    flex: 1 0 88px;
+  }
+  .product-info .size-options .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/assets/section-banner-product.css
+++ b/assets/section-banner-product.css
@@ -1,4 +1,9 @@
 .section__product-banner {
+  --text-primary: #111111;
+  --text-secondary: #737373;
+  --border-color: #ebebeb;
+  --background-light: #f5f5f5;
+  --color-white: #ffffff;
   padding-top: 36px;
   padding-bottom: 12px;
 }
@@ -116,48 +121,60 @@
   background-color: #dc143c;
 }
 
-.product-info .color-options {
+.product-variants .option {
   display: flex;
   gap: 0.5rem;
+  align-items: center;
 }
 
-.product-info .color-button {
-  padding: 0;
-  width: 88px;
-  height: 88px;
+.product-variants .option > button {
   border-radius: 0.5rem;
   border: 1px solid transparent;
   overflow: hidden;
+  color: var(--color-foreground);
 }
 
-.product-info .color-button.active {
-  border-color: var(--text-primary);
+.product-variants .option > button:hover,
+.product-variants .option > button:focus,
+.product-variants .option > button.active {
+  border-color: #000;
+  cursor: pointer;
 }
 
-.product-info .color-button img {
+.product-variants .color-button.active {
+  border-color: #000;
+}
+
+.product-variants .option--color .color-button {
+  padding: 0;
+  width: 88px;
+  height: 88px;
+}
+
+.product-variants .color-button img {
   width: 100%;
   height: auto;
   aspect-ratio: 1 / 1;
   object-fit: cover;
 }
 
-.product-info .size-options .grid {
+.product-variants .option--size .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 0.5rem;
 }
 
-.product-info .size-options .size-button {
+.product-variants .option > button:not(.color-button) {
   padding: 1rem;
   height: 52px;
-  font-size: 0.85rem;
+  font-size: 1.6rem;
   border-radius: 0.5rem;
   border: 1px solid var(--border-color);
   background-color: var(--color-white);
 }
 
-.product-info .size-options .size-button.active,
-.product-info .size-options .size-button:hover {
+.product-variants .option > button:not(.color-button).active,
+.product-variants .option > button:not(.color-button):hover {
   border-color: var(--text-primary);
 }
 

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -173,6 +173,9 @@
         "sale_price": "Sale price",
         "unit_price": "Unit price"
       },
+      "banner-product": {
+        "select_option": "Select {{ option_name}}"
+      },
       "share": "Share this product",
       "sold_out": "Sold out",
       "unavailable": "Unavailable",

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -52,8 +52,28 @@
                {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
               {% endif %}
           </div>
-          {% comment %} TO-DO: Implement product gallery {% endcomment %}
-          <div class="product-gallery" data-color="white"></div>
+          <div class="product-gallery">
+            {% comment %}
+              Display images that match the selected color option
+              If no images match, display the first image
+            {% endcomment %}
+            {% assign selected_color =  target.options[0] | downcase %}
+            {% assign found_image = false %}                        
+            {% for image in product.images %}
+              {% assign image_url = image | image_url: width: 536 | downcase %}              
+              {% if image_url contains selected_color %}
+                <div class="product-gallery__item">
+                {{ image | image_url: width: 536 | image_tag: width: 88, height: 88, alt: image.alt }}
+                {% assign found_image = true %}
+              </div>               
+              {% endif %}
+            {% endfor %}
+            {% if found_image == false and product.images.size > 0 %}
+                <div class="product-gallery__item">
+                  {{ product.images[0] | image_url: width: 536 | image_tag: width: 88, height: 88, alt: product.images[0].alt }}
+                </div>                
+              {% endif %}            
+          </div>
         </div>
         <div class="product-info">
           <div>

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -54,25 +54,59 @@
             <div>
               <h2 class="product-title">{{ product.title }}</h2>
               {{ price }}
+              <div class="product__quantity">
+                {%- unless product.selected_or_first_available_variant.inventory_quantity == 0 or product.selected_or_first_available_variant.available == false -%}
+                  <span class="text-secondary text-medium">In stock:</span>
+                <span class="product--inventory_quantity">{{ product.selected_or_first_available_variant.inventory_quantity }}</span>
+                {%- else -%}
+                  <span class="text--alert text-medium">Out of stock</span>
+                {%- endunless -%}
+                
+              </div>
             </div>
             {% if product.variants.size > 1 %} 
-              {% if product.options contains "Color" %}             
-                <div class="color-options">
-              <p>Select color:</p>
-              {% for color in color_variants limit: 3 %}
-                {% assign repr_variant = product.variants | where: "option1", color | first %}
-                {% assign varian_image = repr_variant.image | default: product.featured_image %}
-                {% assign variant_quantity = repr_variant.inventory_quantity | default: repr_variant.available %}
-                
-                  <button class="color-button" data-variant-id="{{ repr_variant.id }}" data-color="{{ color | downcase }}" data-available="{{ variant_quantity }}">
-                  {% comment %} {{ varian_image | image_url: width: 32, height: 32 | image_tag: alt: variant.title }} {% endcomment %}
-                  {{ color }}
-                  </button>
+              <div class="product-variants">              
+                 {% for option in product.options_with_values %}
+                  {% assign keys = "option1,option2,option3" | split: "," %}
+                  {% assign option_index = forloop.index0 %} 
+                  {% assign option_key = keys[option_index] %}
+  
+                  {% case option.name %}
+                    {%- when "Color" -%}
+                      <p>Select {{option.name | downcase}}:</p>
+                      <div class=" option option--color">
+                        {%- for value in option.values limit: 3 -%}
+                          {% assign variant = product.variants | where: option_key, value | first %}
+                          {% assign variant_quantity = variant.inventory_quantity | default: variant.available %}                          
+                          <button class="color-button" data-variant-id="{{ variant.id }}" data-color="{{ value | downcase }}" data-available="{{ variant_quantity }}">
+                            {% if variant.image %}            
+                            {{ variant.image | image_url: width: 512, height: 512 | image_tag: width: 88, height: 88, alt: variant.image.alt }}
+                            {% else %}
+                              {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
+                            {% endif %}                            
+                            </button>
+                        {%- endfor -%}
+                      </div>
+                    {%- when "Size" -%}
+                      <p>Select {{option.name | downcase}}:</p>
+                      <div class="option option--size">
+                        {%- for value in option.values -%}
+                          <button class="size-button">{{ value }}</button>
+                        {%- endfor -%}
+                      </div>
+                    
+                    {%- else -%}
+                      <p>Select {{option.name | downcase}}:</p>
+                      <div class="option option--generic">
+                        {%- for value in option.values -%}
+                          <button class="generic-button">{{ value }}</button>
+                        {%- endfor -%}
+                      </div>
+                  {% endcase %}
                 {% endfor %}
-                </div>
-              {% endif %}
+              </div>
             {% endif %}
-            <div class="size-options">
+            {% comment %} <div class="size-options">
               <p>Select size:</p>
               <div class="grid">
                 <button class="size-button" data-size="UK 5.5">UK 5.5</button>
@@ -82,7 +116,7 @@
                 <button class="size-button" data-size="UK 7">UK 7</button>
                 <button class="size-button" data-size="UK 7.5">UK 7.5</button>
               </div>
-            </div>
+            </div> {% endcomment %}
             <button class="button button--full-width button--primary add-to-cart">Add to Cart</button>
             {% if product.description != blank %}
               <p class="product-description text-secondary text-medium">{{ product.description }}</p>

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -8,7 +8,7 @@
   assign featured_image_alt = product.featured_image.alt | default: product.title
 
 -%}
-{% comment %} Check a product and use placeholder if product == null
+{% comment %} TO-DO:Check a product and use placeholder if product == null
     assign placeholder = true
 {% endcomment %}
 
@@ -24,9 +24,9 @@
     {%- endif -%}
      <span class="price {% unless available %}price--muted{% endunless %}" data-target="{{ target.id }}">{{ price |  money_with_currency }}</span>
      {%- if available == false -%}
-      <span class="badge badge--soldout">{{ "products.product.sold_out" | t }}</span>
+      <span class="badge badge--soldout">{{ 'products.product.sold_out' | t }}</span>
     {%- elsif compare_at_price > price -%}
-      <span class="badge badge--sale">{{ "products.product.on_sale" | t }}</span>
+      <span class="badge badge--sale">{{ 'products.product.on_sale' | t }}</span>
     {%- endif -%}
   </div>            
 {% endcapture %}
@@ -49,6 +49,7 @@
             {% endif %}
               
           </div>
+          {% comment %} TO-DO: Implement product gallery {% endcomment %}
           <div class="product-gallery" data-color="white"></div>
         </div>
         <div class="product-info">
@@ -78,7 +79,7 @@
                   {% assign option_name = option.name | downcase %}
   
                   {% case option_name %}
-                    {%- when "color", "colour" -%}
+                    {%- when 'color', 'colour' -%}
                       <p>
                         {{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:
                       </p>
@@ -110,21 +111,17 @@
                         {%- endfor -%}
                       </div>
                   {% endcase %}
+
+                  {% if product.options_with_values < 3 %}
+                    {% comment %} There are less than 3 options available {% endcomment %}
+                  {% else %}
+                    {% comment %} There are 3 or more options available {% endcomment %}
+                  {% endif %}
                 {% endfor %}
               </div>
           {% endif %}
-            {% comment %} <div class="size-options">
-              <p>Select size:</p>
-              <div class="grid">
-                <button class="size-button" data-size="UK 5.5">UK 5.5</button>
-                <button class="size-button" data-size="UK 6(EU 39)">UK 6(EU 39)</button>
-                <button class="size-button" data-size="UK 6 (EU 40)">UK 6 (EU 40)</button>
-                <button class="size-button" data-size="UK 6.5">UK 6.5</button>
-                <button class="size-button" data-size="UK 7">UK 7</button>
-                <button class="size-button" data-size="UK 7.5">UK 7.5</button>
-              </div>
-            </div> {% endcomment %}
-          <button class="button button--full-width button--primary add-to-cart">Add to Cart</button>
+          {% comment %} TO-DO: Implement product form {% endcomment %}
+          <button class="button button--full-width button--primary add-to-cart">{{ 'products.product.add_to_cart' | t }}</button>
           {% if product.description != blank %}
              <p class="product-description text-secondary text-medium">{{ product.description }}</p>
            {% endif %}

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -1,5 +1,5 @@
 {%- liquid
-  assign product = section.settings.product
+  assign product = section.settings.product | default: product
   assign color_variants = product.variants | map: 'option1' | uniq
   assign target = product.selected_or_first_available_variant
   assign compare_at_price = target.compare_at_price
@@ -42,12 +42,15 @@
               </svg>
               <span class="badge-text">highly rated</span>
             </div>            
-            {% if product.featured_image %}
-              {{ product.featured_image | image_url: width: 536 | image_tag: alt: featured_image_alt }}
-            {% else %}
-              {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
-            {% endif %}
-              
+            {%- comment -%} Display variant image if it exists, otherwise display product featured image, otherwise display placeholder image {%- endcomment -%}
+              {% assign variant_image = target.image %}
+              {% if variant_image %}
+                {{ variant_image | image_url: width: 536 | image_tag: alt: featured_image_alt }}
+             {% elsif product.featured_image %}
+                {{ product.featured_image | image_url: width: 536 | image_tag: alt: featured_image_alt }}
+             {% else %}
+               {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
+              {% endif %}
           </div>
           {% comment %} TO-DO: Implement product gallery {% endcomment %}
           <div class="product-gallery" data-color="white"></div>
@@ -66,13 +69,13 @@
                   {{ 'products.product.inventory_in_stock_show_count' | t: quantity: target.inventory_quantity }}
                 </span>                  
               {%- else -%}
-                <span class="text--alert text-medium">{{ 'products.product.inventory_in_stock' | t}}</span>
+                <span class="text--alert text-medium">{{ 'products.product.inventory_out_of_stock' | t}}</span>
               {%- endunless -%}                
             </div>
           </div>
           {% if product.variants.size > 1 %} 
               <div class="product-variants">              
-                 {% for option in product.options_with_values %}                
+                {% for option in product.options_with_values %}                
                   {% assign option_name = option.name | downcase %}
   
                   {% case option_name %}
@@ -81,9 +84,8 @@
                         {{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:
                       </p>
                       <div class=" option option--color">
-                        {%- for value in option.values limit: 3 -%}                          
-                          {% assign variant_quantity = value.variant.inventory_quantity | default: value.variant.available %}                          
-                          <button class="color-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}" data-available="{{ variant_quantity }}">
+                        {%- for value in option.values limit: 3 -%}                       
+                          <button class="color-button" data-variant-id="{{ value.variant.id }}" data-product-handle="{{ product.handle }}" data-value="{{ value | downcase }}">
                             {% if value.variant.image %}            
                             {{ value.variant.image | image_url: width: 512, height: 512 | image_tag: width: 88, height: 88, alt: value.variant.image.alt }}
                             {% else %}
@@ -96,23 +98,17 @@
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--size">
                         {%- for value in option.values -%}
-                          <button class="size-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}" data-available="{{ variant_quantity }}">{{ value }}</button>
+                          <button class="size-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}">{{ value }}</button>
                         {%- endfor -%}
                       </div>                    
                     {%- else -%}
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--generic">
                         {%- for value in option.values -%}
-                          <button class="generic-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}" data-available="{{ variant_quantity }}">{{ value }}</button>
+                          <button class="generic-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}">{{ value }}</button>
                         {%- endfor -%}
                       </div>
                   {% endcase %}
-
-                  {% if product.options_with_values < 3 %}
-                    {% comment %} There are less than 3 options available {% endcomment %}
-                  {% else %}
-                    {% comment %} There are 3 or more options available {% endcomment %}
-                  {% endif %}
                 {% endfor %}
               </div>
           {% endif %}

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -1,0 +1,112 @@
+{%- liquid
+  assign product = section.settings.product
+  assign color_variants = product.variants | map: 'option1' | uniq
+  assign target = product.selected_or_first_available_variant
+  assign compare_at_price = target.compare_at_price
+  assign price = target.price | default: 1999
+  assign available = target.available | default: false
+  assign featured_image_alt = product.featured_image.alt | default: product.title
+
+-%}
+{% comment %} Check a product and use placeholder if product == null
+    assign placeholder = true
+  endif {% endcomment %}
+
+{{ 'section-main-product.css' | asset_url | stylesheet_tag }}
+{{ 'section-banner-product.css' | asset_url | stylesheet_tag }}
+
+
+{% capture price %}
+  <div class="price-container">
+    {%- if compare_at_price > price -%}
+      <span class="price price--compare {% unless available %}price--muted{% endunless %}">{{ compare_at_price | money_with_currency }}</span>
+    {%- endif -%}
+     <span class="price {% unless available %}price--muted{% endunless %}" data-target="{{ target.id }}">{{ price | money_with_currency }}</span>
+     {%- if available == false -%}
+      <span class="badge badge--soldout">Sold out</span>
+    {%- elsif compare_at_price > price -%}
+      <span class="badge badge--sale">Sale</span>
+    {%- endif -%}
+  </div>            
+{% endcapture %}
+
+    <section class="section__product-banner">
+      <div class="page-width">
+        <div class="product-card">
+          <div class="product-images">
+            <div class="main-image">
+              <div class="badge">
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 13.0721L7.11574 14.6666L7.66671 11.2895L5.33337 8.89805L8.55789 8.40571L10 5.33325L11.4422 8.40571L14.6667 8.89805L12.3334 11.2895L12.8843 14.6666L10 13.0721Z" fill="#111111" stroke="#111111" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                <span class="badge-text">highly rated</span>
+              </div>            
+              {% if product.featured_image %}
+                {{ product.featured_image | image_url: width: 536 | image_tag: alt: featured_image_alt }}
+              {% else %}
+                {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
+              {% endif %}
+              
+            </div>
+            <div class="product-gallery" data-color="white"></div>
+          </div>
+          <div class="product-info">
+            <div>
+              <h2 class="product-title">{{ product.title }}</h2>
+              {{ price }}
+            </div>
+            {% if product.variants.size > 1 %} 
+              {% if product.options contains "Color" %}             
+                <div class="color-options">
+              <p>Select color:</p>
+              {% for color in color_variants limit: 3 %}
+                {% assign repr_variant = product.variants | where: "option1", color | first %}
+                {% assign varian_image = repr_variant.image | default: product.featured_image %}
+                {% assign variant_quantity = repr_variant.inventory_quantity | default: repr_variant.available %}
+                
+                  <button class="color-button" data-variant-id="{{ repr_variant.id }}" data-color="{{ color | downcase }}" data-available="{{ variant_quantity }}">
+                  {% comment %} {{ varian_image | image_url: width: 32, height: 32 | image_tag: alt: variant.title }} {% endcomment %}
+                  {{ color }}
+                  </button>
+                {% endfor %}
+                </div>
+              {% endif %}
+            {% endif %}
+            <div class="size-options">
+              <p>Select size:</p>
+              <div class="grid">
+                <button class="size-button" data-size="UK 5.5">UK 5.5</button>
+                <button class="size-button" data-size="UK 6(EU 39)">UK 6(EU 39)</button>
+                <button class="size-button" data-size="UK 6 (EU 40)">UK 6 (EU 40)</button>
+                <button class="size-button" data-size="UK 6.5">UK 6.5</button>
+                <button class="size-button" data-size="UK 7">UK 7</button>
+                <button class="size-button" data-size="UK 7.5">UK 7.5</button>
+              </div>
+            </div>
+            <button class="button button--full-width button--primary add-to-cart">Add to Cart</button>
+            {% if product.description != blank %}
+              <p class="product-description text-secondary text-medium">{{ product.description }}</p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </section>
+
+{% schema %}
+{
+  "name": "Banner with product",
+  "settings": [
+    {
+      "type": "product",
+      "id": "product",
+      "label": "Select product"
+    },
+    
+  ],
+  "presets": [
+    {
+      "name": "Banner with product"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -75,9 +75,10 @@
                   {% assign keys = "option1,option2,option3" | split: "," %}
                   {% assign option_index = forloop.index0 %} 
                   {% assign option_key = keys[option_index] %}
+                  {% assign option_name = option.name | downcase %}
   
-                  {% case option.name %}
-                    {%- when "Color" -%}
+                  {% case option_name %}
+                    {%- when "color", "colour" -%}
                       <p>
                         {{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:
                       </p>
@@ -94,7 +95,7 @@
                             </button>
                         {%- endfor -%}
                       </div>
-                    {%- when "Size" -%}
+                    {%- when "size" -%}
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--size">
                         {%- for value in option.values -%}

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -72,10 +72,7 @@
           </div>
           {% if product.variants.size > 1 %} 
               <div class="product-variants">              
-                 {% for option in product.options_with_values %}
-                  {% assign keys = "option1,option2,option3" | split: "," %}
-                  {% assign option_index = forloop.index0 %} 
-                  {% assign option_key = keys[option_index] %}
+                 {% for option in product.options_with_values %}                
                   {% assign option_name = option.name | downcase %}
   
                   {% case option_name %}
@@ -84,12 +81,11 @@
                         {{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:
                       </p>
                       <div class=" option option--color">
-                        {%- for value in option.values limit: 3 -%}
-                          {% assign variant = product.variants | where: option_key, value | first %}
-                          {% assign variant_quantity = variant.inventory_quantity | default: variant.available %}                          
-                          <button class="color-button" data-variant-id="{{ variant.id }}" data-color="{{ value | downcase }}" data-available="{{ variant_quantity }}">
-                            {% if variant.image %}            
-                            {{ variant.image | image_url: width: 512, height: 512 | image_tag: width: 88, height: 88, alt: variant.image.alt }}
+                        {%- for value in option.values limit: 3 -%}                          
+                          {% assign variant_quantity = value.variant.inventory_quantity | default: value.variant.available %}                          
+                          <button class="color-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}" data-available="{{ variant_quantity }}">
+                            {% if value.variant.image %}            
+                            {{ value.variant.image | image_url: width: 512, height: 512 | image_tag: width: 88, height: 88, alt: value.variant.image.alt }}
                             {% else %}
                               {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
                             {% endif %}                            
@@ -100,14 +96,14 @@
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--size">
                         {%- for value in option.values -%}
-                          <button class="size-button">{{ value }}</button>
+                          <button class="size-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}" data-available="{{ variant_quantity }}">{{ value }}</button>
                         {%- endfor -%}
                       </div>                    
                     {%- else -%}
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--generic">
                         {%- for value in option.values -%}
-                          <button class="generic-button">{{ value }}</button>
+                          <button class="generic-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}" data-available="{{ variant_quantity }}">{{ value }}</button>
                         {%- endfor -%}
                       </div>
                   {% endcase %}

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -62,14 +62,28 @@
               {% assign image_url = image | image_url: width: 536 | downcase %}              
               {% if image_url contains selected_color %}
                 <div class="product-gallery__item">
-                {{ image | image_url: width: 536 | image_tag: width: 88, height: 88, alt: image.alt }}
+                {% comment %} {{ image | image_url: width: 536 | image_tag: width: 88, height: 88, alt: image.alt }} {% endcomment %}
+                 <img src="{{ image | image_url: width: 88, height: 88 }}" alt="{{ image.alt  | default: product.title | escape }}" width="88" height="88" class="gallery-thumb" data-large="{{ image | image_url: width: 536 }}" data-srcset="
+            {{ image | image_url: width: 200 }} 200w,
+            {{ image | image_url: width: 400 }} 400w,
+            {{ image | image_url: width: 800 }} 800w,
+            {{ image | image_url: width: 1200 }} 1200w
+          "
+          data-sizes="(max-width: 600px) 100vw, 536px">          
                 {% assign found_image = true %}
               </div>               
               {% endif %}
             {% endfor %}
             {% if found_image == false and product.images.size > 0 %}
                 <div class="product-gallery__item">
-                  {{ product.images[0] | image_url: width: 536 | image_tag: width: 88, height: 88, alt: product.images[0].alt }}
+                  {% comment %} {{ product.images[0] | image_url: width: 536 | image_tag: width: 88, height: 88, alt: product.images[0].alt }} {% endcomment %}
+                  <img src="{{ product.images[0] | image_url: width: 88, height: 88 }}" alt="{{ product.images[0].alt  | default: product.title | escape }}" width="88" height="88" class="gallery-thumb" data-large="{{ product.images[0] | image_url: width: 536 }}" data-srcset="
+          {{ product.images[0] | image_url: width: 200 }} 200w,
+          {{ product.images[0] | image_url: width: 400 }} 400w,
+          {{ product.images[0] | image_url: width: 800 }} 800w,
+          {{ product.images[0] | image_url: width: 1200 }} 1200w
+        "
+        data-sizes="(max-width: 600px) 100vw, 536px">
                 </div>                
               {% endif %}            
           </div>

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -10,18 +10,19 @@
 -%}
 {% comment %} Check a product and use placeholder if product == null
     assign placeholder = true
-  endif {% endcomment %}
+{% endcomment %}
 
 {{ 'section-main-product.css' | asset_url | stylesheet_tag }}
 {{ 'section-banner-product.css' | asset_url | stylesheet_tag }}
 
+<script src="{{ 'banner-product.js' | asset_url }}" defer="defer"></script>
 
 {% capture price %}
   <div class="price-container">
     {%- if compare_at_price > price -%}
-      <span class="price price--compare {% unless available %}price--muted{% endunless %}">{{ compare_at_price | money_with_currency }}</span>
+      <span class="price price--compare {% unless available %}price--muted{% endunless %}">{{ compare_at_price | money_without_trailing_zeros }}</span>
     {%- endif -%}
-     <span class="price {% unless available %}price--muted{% endunless %}" data-target="{{ target.id }}">{{ price | money_with_currency }}</span>
+     <span class="price {% unless available %}price--muted{% endunless %}" data-target="{{ target.id }}">{{ price |  money_with_currency }}</span>
      {%- if available == false -%}
       <span class="badge badge--soldout">Sold out</span>
     {%- elsif compare_at_price > price -%}
@@ -30,41 +31,41 @@
   </div>            
 {% endcapture %}
 
-    <section class="section__product-banner">
-      <div class="page-width">
-        <div class="product-card">
-          <div class="product-images">
-            <div class="main-image">
-              <div class="badge">
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M10 13.0721L7.11574 14.6666L7.66671 11.2895L5.33337 8.89805L8.55789 8.40571L10 5.33325L11.4422 8.40571L14.6667 8.89805L12.3334 11.2895L12.8843 14.6666L10 13.0721Z" fill="#111111" stroke="#111111" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                <span class="badge-text">highly rated</span>
-              </div>            
-              {% if product.featured_image %}
-                {{ product.featured_image | image_url: width: 536 | image_tag: alt: featured_image_alt }}
-              {% else %}
-                {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
-              {% endif %}
+  <section class="section__product-banner">
+    <div class="page-width">
+      <div class="product-card">
+        <div class="product-images">
+          <div class="main-image">
+            <div class="badge">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M10 13.0721L7.11574 14.6666L7.66671 11.2895L5.33337 8.89805L8.55789 8.40571L10 5.33325L11.4422 8.40571L14.6667 8.89805L12.3334 11.2895L12.8843 14.6666L10 13.0721Z" fill="#111111" stroke="#111111" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="badge-text">highly rated</span>
+            </div>            
+            {% if product.featured_image %}
+              {{ product.featured_image | image_url: width: 536 | image_tag: alt: featured_image_alt }}
+            {% else %}
+              {{ 'image' | placeholder_svg_tag: 'placeholder-svg-class' }}
+            {% endif %}
               
-            </div>
-            <div class="product-gallery" data-color="white"></div>
           </div>
-          <div class="product-info">
-            <div>
-              <h2 class="product-title">{{ product.title }}</h2>
-              {{ price }}
-              <div class="product__quantity">
-                {%- unless product.selected_or_first_available_variant.inventory_quantity == 0 or product.selected_or_first_available_variant.available == false -%}
-                  <span class="text-secondary text-medium">In stock:</span>
-                <span class="product--inventory_quantity">{{ product.selected_or_first_available_variant.inventory_quantity }}</span>
-                {%- else -%}
-                  <span class="text--alert text-medium">Out of stock</span>
-                {%- endunless -%}
-                
-              </div>
+          <div class="product-gallery" data-color="white"></div>
+        </div>
+        <div class="product-info">
+          <div>
+            {% if product.title != blank %}
+            <h2 class="product-title">{{ product.title | escape}}</h2>
+            {% endif %}
+            {{ price }}
+            <div class="product--inventory_quantity">
+              {%- unless target.available == false -%}
+                <span class="text-secondary text-medium">In stock: {{ target.inventory_quantity }}</span>
+              {%- else -%}
+                <span class="text--alert text-medium">Out of stock</span>
+              {%- endunless -%}                
             </div>
-            {% if product.variants.size > 1 %} 
+          </div>
+          {% if product.variants.size > 1 %} 
               <div class="product-variants">              
                  {% for option in product.options_with_values %}
                   {% assign keys = "option1,option2,option3" | split: "," %}
@@ -105,7 +106,7 @@
                   {% endcase %}
                 {% endfor %}
               </div>
-            {% endif %}
+          {% endif %}
             {% comment %} <div class="size-options">
               <p>Select size:</p>
               <div class="grid">
@@ -117,16 +118,17 @@
                 <button class="size-button" data-size="UK 7.5">UK 7.5</button>
               </div>
             </div> {% endcomment %}
-            <button class="button button--full-width button--primary add-to-cart">Add to Cart</button>
-            {% if product.description != blank %}
-              <p class="product-description text-secondary text-medium">{{ product.description }}</p>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </section>
+          <button class="button button--full-width button--primary add-to-cart">Add to Cart</button>
+          {% if product.description != blank %}
+             <p class="product-description text-secondary text-medium">{{ product.description }}</p>
+           {% endif %}
+         </div>
+       </div>
+     </div>
+  </section>
 
-{% schema %}
+
+    {% schema %}
 {
   "name": "Banner with product",
   "settings": [

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -1,6 +1,5 @@
 {%- liquid
   assign product = section.settings.product | default: product
-  assign color_variants = product.variants | map: 'option1' | uniq
   assign target = product.selected_or_first_available_variant
   assign compare_at_price = target.compare_at_price
   assign price = target.price | default: 1999
@@ -105,7 +104,7 @@
                       </p>
                       <div class=" option option--color">
                         {%- for value in option.values limit: 3 -%}                       
-                          <button class="color-button" data-variant-id="{{ value.variant.id }}" data-product-handle="{{ product.handle }}" data-value="{{ value | downcase }}">
+                          <button class="color-button {% if option.selected_value == value %} active{% endif %}" data-variant-id="{{ value.variant.id }}" data-product-handle="{{ product.handle }}" data-value="{{ value | downcase }}">
                             {% if value.variant.image %}            
                             {{ value.variant.image | image_url: width: 512, height: 512 | image_tag: width: 88, height: 88, alt: value.variant.image.alt }}
                             {% else %}
@@ -118,14 +117,14 @@
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--size">
                         {%- for value in option.values -%}
-                          <button class="size-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}">{{ value }}</button>
+                          <button class="size-button {% if option.selected_value == value %}active{% endif %}" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}">{{ value }}</button>
                         {%- endfor -%}
                       </div>                    
                     {%- else -%}
                       <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--generic">
                         {%- for value in option.values -%}
-                          <button class="generic-button" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}">{{ value }}</button>
+                          <button class="generic-button {% if option.selected_value == value %} active{% endif %}" data-variant-id="{{ value.variant.id }}" data-value="{{ value | downcase }}">{{ value }}</button>
                         {%- endfor -%}
                       </div>
                   {% endcase %}

--- a/sections/banner-product.liquid
+++ b/sections/banner-product.liquid
@@ -24,9 +24,9 @@
     {%- endif -%}
      <span class="price {% unless available %}price--muted{% endunless %}" data-target="{{ target.id }}">{{ price |  money_with_currency }}</span>
      {%- if available == false -%}
-      <span class="badge badge--soldout">Sold out</span>
+      <span class="badge badge--soldout">{{ "products.product.sold_out" | t }}</span>
     {%- elsif compare_at_price > price -%}
-      <span class="badge badge--sale">Sale</span>
+      <span class="badge badge--sale">{{ "products.product.on_sale" | t }}</span>
     {%- endif -%}
   </div>            
 {% endcapture %}
@@ -56,12 +56,16 @@
             {% if product.title != blank %}
             <h2 class="product-title">{{ product.title | escape}}</h2>
             {% endif %}
-            {{ price }}
+            {%  if price != blank %}
+              {{ price }}
+            {% endif %}
             <div class="product--inventory_quantity">
               {%- unless target.available == false -%}
-                <span class="text-secondary text-medium">In stock: {{ target.inventory_quantity }}</span>
+                <span class="text-secondary text-medium">
+                  {{ 'products.product.inventory_in_stock_show_count' | t: quantity: target.inventory_quantity }}
+                </span>                  
               {%- else -%}
-                <span class="text--alert text-medium">Out of stock</span>
+                <span class="text--alert text-medium">{{ 'products.product.inventory_in_stock' | t}}</span>
               {%- endunless -%}                
             </div>
           </div>
@@ -74,7 +78,9 @@
   
                   {% case option.name %}
                     {%- when "Color" -%}
-                      <p>Select {{option.name | downcase}}:</p>
+                      <p>
+                        {{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:
+                      </p>
                       <div class=" option option--color">
                         {%- for value in option.values limit: 3 -%}
                           {% assign variant = product.variants | where: option_key, value | first %}
@@ -89,15 +95,14 @@
                         {%- endfor -%}
                       </div>
                     {%- when "Size" -%}
-                      <p>Select {{option.name | downcase}}:</p>
+                      <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--size">
                         {%- for value in option.values -%}
                           <button class="size-button">{{ value }}</button>
                         {%- endfor -%}
-                      </div>
-                    
+                      </div>                    
                     {%- else -%}
-                      <p>Select {{option.name | downcase}}:</p>
+                      <p>{{ 'products.product.banner-product.select_option' | t: option_name: option.name | default: option.name }}:</p>
                       <div class="option option--generic">
                         {%- for value in option.values -%}
                           <button class="generic-button">{{ value }}</button>

--- a/templates/index.json
+++ b/templates/index.json
@@ -114,10 +114,18 @@
         "padding_top": 44,
         "padding_bottom": 36
       }
+    },
+    "banner_product_UQWCJh": {
+      "type": "banner-product",
+      "name": "Banner with product",
+      "settings": {
+        "product": "the-liquid-basics-test-product"
+      }
     }
   },
   "order": [
     "slideshow_eykfjd",
-    "featured_collection"
+    "featured_collection",
+    "banner_product_UQWCJh"
   ]
 }

--- a/templates/index.json
+++ b/templates/index.json
@@ -87,6 +87,13 @@
         "accessibility_info": "Slideshow about our brand"
       }
     },
+    "banner_product_UQWCJh": {
+      "type": "banner-product",
+      "name": "Banner with product",
+      "settings": {
+        "product": "the-liquid-basics-test-product"
+      }
+    },
     "featured_collection": {
       "type": "featured-collection",
       "settings": {
@@ -114,18 +121,11 @@
         "padding_top": 44,
         "padding_bottom": 36
       }
-    },
-    "banner_product_UQWCJh": {
-      "type": "banner-product",
-      "name": "Banner with product",
-      "settings": {
-        "product": "the-liquid-basics-test-product"
-      }
     }
   },
   "order": [
     "slideshow_eykfjd",
-    "featured_collection",
-    "banner_product_UQWCJh"
+    "banner_product_UQWCJh",
+    "featured_collection"
   ]
 }

--- a/templates/index.json
+++ b/templates/index.json
@@ -91,7 +91,7 @@
       "type": "banner-product",
       "name": "Banner with product",
       "settings": {
-        "product": "the-liquid-basics-test-product"
+        "product": "nike-air-max-plus"
       }
     },
     "featured_collection": {


### PR DESCRIPTION
## 📋 Опис завдання
Створити банер (на основі дизайну у Figma), який отримує продукти та рендерить його назву, ціну, зображення, варіанти. При кліку на варіант кольору, показується кількість товарів. 
## ✅ Реалізований функціонал
- [x] Створено тестовий продукт, що покриває edge cases (compare_at_price, variants > 5, quantity/not avaliable)
- [x] Банер зроблений як секція, що має поле для вибору продутку. 
- [x] Виводиться зображення продукту або placeholder. Зображення має alt => або alt, або product.title
- [x] Галерея продуктів виводиться відповідно до обраного варіанту кольору. Фільтрація товарів відбувається за назвою зображення (чи містить у назві відповідний колір). Якщо для варіанту продукту не знайдено зображень, виводиться featured_image. 
 - [x] Головне зображення змінюється при кліку на зображення у галереї
- [x] Ціна: блок винесиний у capture; відображається compare_at_price (якщо зазначено); використані фільтри money_with_currency та money_without_trailing_zeros; виводяться бейджі "sale", "sold out"
- [x] Безпечне виведення даних: перевірка на !=blank, фільтри default, downcase, escape
- [x] Якщо продукт має варіанти, то виводяться блоки опцій. Для опцій "Color", "Size" рендериться окремий блок, а для решти опцій - загальний. Перевірка відбувається через case / when.
- [x] Реалізовано ре-рендиренг ціни, зображення та кількість продукту через Section rendering API.
- [x] Для кожної кнопки варіантів додає data-атрибути value.variant.id та product.handle, щоб ре-рендирити необхідні фрагменти (блок ціни, зображення та кількість)
- [x] Якщо варіант не має зображення -> placeholder
- [x] При кліку на варіант кольору змінюється доступна кількість товару (In stock x / Out of stock), ціна та зображення.
- [x] Статичні рядкові дані виводяться через фільтр t (translate).
- [x] Додано кастомне значення у en.default.json : 'products.product.banner-product.select_option'
- [x] Підключено кастомні скрипти та стилі

## 🔧 Технології та підходи
Liquid:
- фільтри: downcase, escape, default, translate, split
- фільтри для масивів: size, where,  first
- фільтри ціни
- умови if, unless, case/when
- цикл for: forloop.index0, limit
- image_url, image_tag + placeholder_svg_tag
- Section Rendering API


## 📝 Примітки
- Виникли труднощі із "прокиданням" даних обраного варіанту продукту. Також треба було врахувати різницю між Variant та Option у Shopify, щоб коректно фільтрувати та виводити доступні варіанти товарів. 
- Першочергово планувала ре-рендирити секцію за допомогою JS: передавати продукт як JSON. Проте для збереження логіки цінового блоку та галереї, яка на писана через Liquid, було б потрібно частково дуюлювати цю логіку у JS. тому вирішила спробувати ре-рендирити фрагменти секції через Section Rendering API. 
- Оскільки продукт у секції додається через поле з вибором продуктів і секція може бути додана на будь-яку сторінку, у fetch запиті я звертаюся до сторінки продукту та конкретного варіанту, а у самій секції додала fallback для змінної продукту: `assign product = section.settings.product | default: product`

## Потрібно допрацювати
- [ ] Додати Swiper Slider
- [ ] Бейджі на зображення
- [ ] Placeholder для всього блоку, якщо продукт не обрано (коли секція лише додається на сторінку або для прев'ю) 

## 🔗 Пов'язані ресурси
- [Нотатка в Asana](https://app.asana.com/1/442123638460530/project/1211341031891413/task/1211341031891441?focus=true)